### PR TITLE
init should hash

### DIFF
--- a/src/fast.ts
+++ b/src/fast.ts
@@ -43,7 +43,7 @@ class FastSemaphore extends BaseSemaphore {
 
     //sometimes identityCommitments array can be to big so we must generate it on server and just use it on frontend
     async genProofFromBuiltTree(identity: Identity, merkleProof: any, externalNullifier: string | bigint, signal: string, 
-        wasmFilePath: string, finalZkeyPath: string, shouldHash: boolean): Promise<IProof> {
+        wasmFilePath: string, finalZkeyPath: string, shouldHash: boolean = true): Promise<IProof> {
 
         const grothInput: any = {
             identity_nullifier: identity.identityNullifier,


### PR DESCRIPTION
Hello, an error occurred while using semaphore_lib and pr was created.
As the boolean should hash parameter is added, the error below occurs in the code that was previously working.

An argument for 'shouldHash' was not provided.


Therefore, it has been modified as follows.

before
```
shouldHash: boolean
```
after
```
shouldHash: boolean=true
```